### PR TITLE
Missing semicolon at end of line 36 in hass-configurator

### DIFF
--- a/hass-configurator.subdomain.conf.sample
+++ b/hass-configurator.subdomain.conf.sample
@@ -33,7 +33,7 @@ server {
         #include /config/nginx/authelia-location.conf;
 
         include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf
+        include /config/nginx/resolver.conf;
         set $upstream_app hass-configurator;
         set $upstream_port 3218;
         set $upstream_proto http;


### PR DESCRIPTION
The missing semicolon caused swag to hang at start if hass-configurator.subdomain.conf is enabled